### PR TITLE
Aggiorna città da Roma a Barletta

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Scuola di Tango Argentino - Corsi, Lezioni e Eventi di Tango a Roma">
+    <meta name="description" content="Scuola di Tango Argentino - Corsi, Lezioni e Eventi di Tango a Barletta">
     <title>Pasión Tango - Scuola di Tango Argentino</title>
     <link rel="stylesheet" href="css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -266,11 +266,11 @@
                     <h3>Vieni a Trovarci</h3>
                     <div class="info-item">
                         <h4>Indirizzo</h4>
-                        <p>Via del Tango 15<br>00184 Roma, Italia</p>
+                        <p>Via del Tango 15<br>76121 Barletta, Italia</p>
                     </div>
                     <div class="info-item">
                         <h4>Telefono</h4>
-                        <p>+39 06 1234 5678</p>
+                        <p>+39 0883 1234 5678</p>
                     </div>
                     <div class="info-item">
                         <h4>Email</h4>
@@ -314,7 +314,7 @@
             <div class="footer-content">
                 <div class="footer-brand">
                     <h3>Pasión Tango</h3>
-                    <p>L'arte del tango argentino a Roma</p>
+                    <p>L'arte del tango argentino a Barletta</p>
                 </div>
                 <div class="footer-links">
                     <h4>Link Utili</h4>


### PR DESCRIPTION
## Summary
- Aggiornata la città della scuola di tango da Roma a Barletta
- Modificato il CAP da 00184 a 76121
- Aggiornato il prefisso telefonico da 06 a 0883

## Test plan
- [ ] Verificare che tutte le occorrenze di "Roma" siano state cambiate in "Barletta"
- [ ] Controllare che il nuovo indirizzo sia corretto
- [ ] Verificare il deploy su GitHub Pages dopo il merge

🤖 Generated with [Claude Code](https://claude.ai/code)