### PR TITLE
Fix: Correggi indirizzo scuola (fixes #4)

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@
                     <h3>Vieni a Trovarci</h3>
                     <div class="info-item">
                         <h4>Indirizzo</h4>
-                        <p>Via del Tango 15<br>76121 Barletta, Italia</p>
+                        <p>Via Barberini 206<br>76121 Barletta, Italia</p>
                     </div>
                     <div class="info-item">
                         <h4>Telefono</h4>


### PR DESCRIPTION
## Summary
- Corretto l'indirizzo della scuola da "Via del Tango 15" a "Via Barberini 206"
- Risolve l'issue #4

## Changes
- Aggiornato indirizzo nella sezione contatti

## Test plan
- [ ] Verificare che l'indirizzo sia correttamente visualizzato come "Via Barberini 206"
- [ ] Verificare che il CAP rimanga 76121 Barletta

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)